### PR TITLE
타이머 화면과 하단 바 추가, 네비게이션 및 빌드 파일 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,4 +76,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    implementation("androidx.compose.material:material-icons-extended")
 }

--- a/app/src/main/java/com/example/studify/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/studify/presentation/MainActivity.kt
@@ -7,8 +7,11 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.studify.presentation.components.BottomNavigationBar
 import com.example.studify.presentation.navigation.StudifyNavGraph
 import com.example.studify.presentation.ui.theme.StudifyTheme
 
@@ -19,7 +22,15 @@ class MainActivity : ComponentActivity() {
         setContent {
             StudifyTheme {
                 val navController = rememberNavController()
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentRoute = navBackStackEntry?.destination?.route
+                Scaffold(modifier = Modifier.fillMaxSize(),
+                    bottomBar = {
+                        // onboarding이나 login 화면이 아니면 보여줌
+                        if (currentRoute !in listOf("onboarding", "login")) {
+                            BottomNavigationBar(navController)
+                        }
+                    }) { innerPadding ->
                     StudifyNavGraph(
                         navController = navController,
                         modifier = Modifier.padding(innerPadding),

--- a/app/src/main/java/com/example/studify/presentation/TimerScreen.kt
+++ b/app/src/main/java/com/example/studify/presentation/TimerScreen.kt
@@ -1,0 +1,124 @@
+package com.example.studify.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.material3.ButtonDefaults.buttonColors
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimerScreen() {
+    val subjects = listOf("운영체제", "데이터베이스", "소프트웨어")
+    var selectedSubject by remember { mutableStateOf(subjects[0]) }
+    var isRunning by remember { mutableStateOf(false) }
+    var isPaused by remember { mutableStateOf(false) }
+    var timeLeft by remember { mutableStateOf(25 * 60) } // 25분
+
+    // 타이머 로직
+    LaunchedEffect(isRunning, isPaused) {
+        while (isRunning && !isPaused && timeLeft > 0) {
+            delay(1000L)
+            timeLeft--
+        }
+    }
+
+    val minutes = timeLeft / 60
+    val seconds = timeLeft % 60
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFE0F0FF))
+            .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("타이머", fontSize = 22.sp, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text("과목을 선택하고 공부 시간을 기록하세요")
+
+        Spacer(modifier = Modifier.height(20.dp))
+        // 과목 선택 드롭다운
+        var expanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+            TextField(
+                value = selectedSubject,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("과목 선택") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                modifier = Modifier.menuAnchor()
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                subjects.forEach {
+                    DropdownMenuItem(
+                        text = { Text(it) },
+                        onClick = {
+                            selectedSubject = it
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(String.format("%02d:%02d", minutes, seconds), fontSize = 48.sp)
+
+        Spacer(modifier = Modifier.height(20.dp))
+        Row(modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly) {
+            Button(onClick = { isRunning = true; isPaused = false }, colors = buttonColors(containerColor = Color.Green)) {
+                Text("시작")
+            }
+            Spacer(modifier = Modifier.width(10.dp))
+            Button(onClick = { isPaused = true }, colors = buttonColors(containerColor = Color.Blue)) {
+                Text("일시정지")
+            }
+            Spacer(modifier = Modifier.width(10.dp))
+            Button(onClick = {
+                isRunning = false
+                isPaused = false
+                timeLeft = 25 * 60
+            }, colors = buttonColors(containerColor = Color.Red)) {
+                Text("종료")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+        Text("과목별 진행률", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(10.dp))
+        SubjectProgress("OS", 5, 10)
+        SubjectProgress("SW", 2, 6)
+        SubjectProgress("DB", 1, 8)
+    }
+}
+
+@Composable
+fun SubjectProgress(name: String, current: Int, total: Int) {
+    val percent = (current.toFloat() / total.toFloat())
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+        Text("$name")
+        LinearProgressIndicator(
+            progress = percent,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp)),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = Color.LightGray
+        )
+        Text("${current}h / ${total}h (${(percent * 100).toInt()}%)", fontSize = 12.sp)
+    }
+}
+
+

--- a/app/src/main/java/com/example/studify/presentation/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/studify/presentation/components/BottomNavigationBar.kt
@@ -1,0 +1,51 @@
+package com.example.studify.presentation.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+sealed class BottomNavItem(val route: String, val label: String, val icon: ImageVector) {
+    object Home : BottomNavItem("home", "홈", Icons.Default.Home)
+    object Plan : BottomNavItem("plan", "계획", Icons.Filled.EditCalendar)
+    object Timer : BottomNavItem("timer", "타이머", Icons.Filled.Timer)
+    object Stat : BottomNavItem("stat", "통계", Icons.Filled.BarChart)
+}
+
+val bottomNavItems = listOf(
+    BottomNavItem.Home,
+    BottomNavItem.Plan,
+    BottomNavItem.Timer,
+    BottomNavItem.Stat
+)
+
+@Composable
+fun BottomNavigationBar(navController: NavController) {
+    val navBackStackEntry = navController.currentBackStackEntryAsState().value
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    NavigationBar {
+        bottomNavItems.forEach { item ->
+            NavigationBarItem(
+                selected = currentRoute == item.route,
+                onClick = {
+                    if (currentRoute != item.route) {
+                        navController.navigate(item.route) {
+                            // 중복 방지
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                icon = { Icon(imageVector = item.icon, contentDescription = item.label) },
+                label = { Text(item.label) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/studify/presentation/navigation/StudifyNavGraph.kt
+++ b/app/src/main/java/com/example/studify/presentation/navigation/StudifyNavGraph.kt
@@ -15,6 +15,7 @@ fun StudifyNavGraph(
     NavHost(
         navController = navController,
         startDestination = Screen.Onboarding.route,
+        modifier = modifier
     ) {
         composable(route = Screen.Onboarding.route) {
             Text("Onboarding Screen")
@@ -23,19 +24,19 @@ fun StudifyNavGraph(
             Text("Login Screen")
         }
         composable(route = Screen.Home.route) {
-            Text("Home Screen")
+            Text("\uD83C\uDFE0 Home Screen")
         }
         composable(route = Screen.Plan.route) {
-            Text("Plan Screen")
+            Text("\uD83D\uDDD3\uFE0F Plan Screen")
         }
         composable(route = Screen.Timer.route) {
-            Text("Timer Screen")
+            Text("⏱\uFE0F Timer Screen")
         }
         composable(route = Screen.Stat.route) {
-            Text("Statistics Screen")
+            Text("\uD83D\uDCCA Statistics Screen")
         }
         composable(route = Screen.Profile.route) {
-            Text("Profile Screen")
+            Text("\uD83D\uDC64 Profile Screen")
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 제목 예시
feat: 타이머 화면 생성 및 하단 바 추가하고 네비게이션 수정했습니다.

---
타이머 화면에 과목 선택, 타이머 시작/일시정지/리셋 기능들 완료하고 BottomNavigationBar에 홈, 계획, 타이머, 통계 등 탭을 아이콘과 함께 추가하고 해당 탭을 눌렀을 때 NavController를 통해 화면을 전환하도록 구현했습니다. 



